### PR TITLE
Updated the Convert-M365DSCExportToPowerShellDataFile function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Generates UniqueId properties for the collections that require it.
   - Runs a Pester test to test if the exported values are of the right type and if
     all required properties are present.
+  - Add possibility to use PowerShell v7+, where some code is proxying requests via
+    PowerShell v5.1.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the convert export function to:
+  - Check the schema for which type is expected for a specific resource, an array or
+    an hashtable, and uses the correct type.
+  - Generates UniqueId properties for the collections that require it.
+  - Runs a Pester test to test if the exported values are of the right type and if
+    all required properties are present.
+
+### Fixed
+
+- Fixed issue in the Test function where DateTime objects are stored in string
+  format, but the Test really checks for the DateTime type. Now testing if the
+  string is in a correct DateTime format.
+
 ## [0.4.6] - 2025-03-18
 
 ### Added

--- a/source/Private/Get-RefNodeExampleData.ps1
+++ b/source/Private/Get-RefNodeExampleData.ps1
@@ -37,25 +37,33 @@ function Get-RefNodeExampleData
         {
             if ($Node.GetType().FullName -eq 'PSLeafNode')
             {
-                $ArrayResult = $Result.split('|').foreach{ $_.trim() }
-                $LeafNode = @{}
-                if ( $ArrayResult[0])
+                if ($Result -is [System.String])
                 {
-                    $LeafNode.add('Type', $ArrayResult[0])
+                    $ArrayResult = $Result.Split('|').ForEach{ $_.Trim() }
+                    $LeafNode = @{}
+                    if ( $ArrayResult[0])
+                    {
+                        $LeafNode.Add('Type', $ArrayResult[0])
+                    }
+                    if ( $ArrayResult[1])
+                    {
+                        $LeafNode.Add('Required', $ArrayResult[1])
+                    }
+                    if ( $ArrayResult[2])
+                    {
+                        $LeafNode.Add('Description', $ArrayResult[2])
+                    }
+                    if ( $ArrayResult[3])
+                    {
+                        $LeafNode.Add('ValidateSet', "'" + ( $ArrayResult[3] -Replace '\s*\/\s*', "', '") + "'"  )
+                    }
+                    return $LeafNode
                 }
-                if ( $ArrayResult[1])
+                else
                 {
-                    $LeafNode.add('Required', $ArrayResult[1])
+                    Write-Warning "No data found for path: $($Node.Path)"
+                    return $null
                 }
-                if ( $ArrayResult[2])
-                {
-                    $LeafNode.add('Description', $ArrayResult[2])
-                }
-                if ( $ArrayResult[3])
-                {
-                    $LeafNode.add('ValidateSet', "'" + ( $ArrayResult[3] -Replace '\s*\/\s*', "', '") + "'"  )
-                }
-                return $LeafNode
             }
             else
             {

--- a/source/Public/Convert-M365DSCExportToPowerShellDataFile.ps1
+++ b/source/Public/Convert-M365DSCExportToPowerShellDataFile.ps1
@@ -5,7 +5,8 @@ $DSC_ExcludeKeys = @(
     'CertificateThumbprint',
     'TenantId',
     'IsSingleInstance',
-    'CIMInstance'
+    'CIMInstance',
+    'Credential'
 )
 
 function Convert-M365DSCExportToPowerShellDataFile
@@ -19,8 +20,8 @@ function Convert-M365DSCExportToPowerShellDataFile
     a PowerShell data file (.psd1) format that complies with the structure
     used in the M365DSC.CompositeResources module.
 
-    It uses the function New-M365DSCReportFromConfiguration to convert the
-    export into JSON before converting it into a PowerShell data file.
+    It uses the function ConvertTo-DscObject to convert the export into a
+    PowerShell object before converting it into a PowerShell data file.
 
 .PARAMETER Workload
     The Workload for which you want to convert the export.
@@ -28,28 +29,48 @@ function Convert-M365DSCExportToPowerShellDataFile
 .PARAMETER SourceFile
     The file which contains the Microsoft365DSC export.
 
-.PARAMETER ResultFolder
-    The folder to which the converted file is written to.
+.PARAMETER ResultFile
+    The file to which the converted file is written to.
+
+.PARAMETER SkipPesterTests
+    If specified, the Pester tests will not be run on the converted data.
+
+.PARAMETER ShowPesterScripts
+    If specified, the generated Pester scripts will be shown in the output.
+    NOTE: Does require the use of the PowerShell ISE
 
 .EXAMPLE
     Convert-M365DSCExportToPowerShellDataFile `
         -Workload Office365 `
         -SourceFile '.\Exports\O365\O365.ps1' `
-        -ResultFolder '.\Results'
+        -ResultFile '.\Results\O365\O365.psd1'
 #>
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingCmdletAliases', '', Scope = 'Function')]
     [CmdletBinding()]
     param
     (
         [Parameter(Mandatory = $true)]
-        [ValidateSet( 'AzureAD', 'Exchange', 'Intune', 'Office365', 'OneDrive', 'Planner', 'PowerPlatform', 'SecurityCompliance', 'SharePoint', 'Teams')]
+        [ValidateSet('Azure', 'AzureAD', 'AzureDevOps',
+                    'Commerce', 'Defender', 'Exchange',
+                    'Fabric', 'Intune', 'Office365',
+                    'OneDrive', 'Planner', 'PowerPlatform',
+                    'SecurityCompliance', 'Sentinel', 'ServicesHub',
+                    'SharePoint', 'Teams')]
         $Workload,
 
         [Parameter(Mandatory = $true, ValueFromPipeline = $True)]
         $SourceFile,
 
         [Parameter(Mandatory = $true)]
-        $ResultFolder
+        $ResultFile,
+
+        [Parameter()]
+        [Switch]
+        $SkipPesterTests,
+
+        [Parameter()]
+        [Switch]
+        $ShowPesterScripts
     )
 
     begin
@@ -60,67 +81,121 @@ function Convert-M365DSCExportToPowerShellDataFile
             Import-Module ObjectGraphTools -Force
         }
 
-        Class DSCConversion
+        class DSCConversion
         {
             [string]$Resource_Name
             [string]$Composite_Resource_Name
             [hashtable[]]$Resource_Objects
+            [boolean]$IsCollection
+            [boolean]$RequiresUniqueId
         }
 
-        # Fix bug second run
-        Set-M365DSCTelemetryOption -Enabled $false
+        function ConvertFrom-HashTable
+        {
+            param
+            (
+                [Parameter(Mandatory, ValueFromPipeline)]
+                [System.Collections.IDictionary]
+                $HashTable
+            )
+            process
+            {
+                $NewObject = [ordered] @{}
+                foreach ($entry in $HashTable.GetEnumerator())
+                {
+                    if ($entry.Value -is [System.Collections.IDictionary])
+                    {
+                        $NewObject[[object] $entry.Key] = ConvertFrom-HashTable -HashTable $entry.Value # NOTE: Casting to [object] prevents problems with *numeric* hashtable keys.
+                    }
+                    else
+                    {
+                        $NewObject[[object] $entry.Key] = $entry.Value
+                    }
+                }
+                [pscustomobject] $NewObject
+            }
+        }
     }
 
     process
     {
-        $SourceFile_BaseName = (Get-Item $SourceFile).BaseName
-        $Path_JsonReport = '{0}_M365DSCReport.json' -f $( Join-Path -Path $ResultFolder -ChildPath $SourceFile_BaseName)
-        $Path_CompositeConfig = '{0}.psd1' -f $( Join-Path -Path $ResultFolder -ChildPath $SourceFile_BaseName)
-
-        New-Item -ItemType Directory -Force -Path $ResultFolder | Out-Null
-
         '--- Create composite config for M365 DSC ---' | Write-Log
         'Workload     : {0}' -f $Workload | Write-Log
-        'SourceFile   : {0}' -f $SourceFile | Write-Log
-        'ResultFolder : {0}' -f $ResultFolder | Write-Log
+        'Resourcefile : {0}' -f $SourceFile | Write-Log
+        'ResultFolder : {0}' -f $ResultFile | Write-Log
 
+        if ((Test-Path -Path $SourceFile) -eq $false)
+        {
+            Write-Error "Cannot find file specified in parameter Source: $SourceFile,. Please make sure the file exists!"
+            return
+        }
 
-        # Create M365DSCReport
-        $OriginalProgressPreference = $Global:ProgressPreference
-        $Global:ProgressPreference = 'SilentlyContinue'
-        New-M365DSCReportFromConfiguration -Type JSON -ConfigurationPath $SourceFile -OutputPath $Path_JsonReport
-        $Global:ProgressPreference = $OriginalProgressPreference
+        $fileContent = Get-Content $SourceFile -Raw
+        try
+        {
+            $startPosition = $fileContent.IndexOf(' -ModuleVersion')
+            if ($startPosition -gt 0)
+            {
+                $endPosition = $fileContent.IndexOf("`r", $startPosition)
+                $fileContent = $fileContent.Remove($startPosition, $endPosition - $startPosition)
+            }
+        }
+        catch
+        {
+            Write-Verbose 'Error trying to remove Module Version'
+        }
 
-        # load M365DSCReport
-        $Obj_Export = Get-Content $Path_JsonReport | ConvertFrom-Json
-
-        # Load Example data from module M365DSC.CompositeResources
-        $M365DSCCRModule = Get-Module -ListAvailable M365DSC.CompositeResources | Sort-Object -Property Version | Select-Object -Last 1
-        $Obj_M365DataExample = Import-PSDataFile -Path (Join-Path -Path ($M365DSCCRModule.Path | Split-Path) -ChildPath 'M365ConfigurationDataExample.psd1').ToString()
+        'Converting read data into object' | Write-Log
+        if ($PSVersionTable.PSVersion -gt [Version]"7.0.0.0")
+        {
+            '- Using PowerShell v7+, proxying conversion via PowerShell v5.1' | Write-Log
+            [Array]$parsedContent = Start-Job -ScriptBlock {
+                [Array]$parsedContent = ConvertTo-DSCObject -Content $args[0]
+                return $parsedContent
+            } -ArgumentList $fileContent -PSVersion 5.1 | Wait-Job | Receive-Job
+        }
+        else
+        {
+            '- Using PowerShell v5.1' | Write-Log
+            [Array]$parsedContent = ConvertTo-DSCObject -Content $fileContent
+        }
+        $Obj_Export = $parsedContent.ForEach{ $_ | ConvertFrom-HashTable }
 
         # Group Object
         $Obj_Export_Groups = $Obj_Export | Group-Object 'resourcename'
-        'Found Grouped Items : {0}' -f $Obj_Export_Groups.count | Write-Log
+        'Found Grouped Items : {0}' -f $Obj_Export_Groups.Count | Write-Log
 
+        # Load Example data from module M365DSC.CompositeResources
+        'Looking for Example Data File' | Write-Log
+        $M365DSCCRModule = Get-Module -ListAvailable M365DSC.CompositeResources | Sort-Object -Property Version | Select-Object -Last 1
+        if ($null -eq $M365DSCCRModule)
+        {
+            "Could not find module M365DSC.CompositeResources! Exiting!" | Write-Log -Failure
+            return
+        }
+        $Obj_M365DataExample = Import-PSDataFile -Path (Join-Path -Path ($M365DSCCRModule.Path | Split-Path) -ChildPath 'M365ConfigurationDataExample.psd1').ToString()
+
+        'Processing exported resources' | Write-Log
         $Obj_Grouped = @(
             foreach ($Obj_Export_Group in $Obj_Export_Groups)
             {
-                $Obj_Conversion = [DSCConversion]::new()
-                $Obj_Conversion.Resource_Name = $Obj_Export_Group.name
+                $Obj_Conversion = [DSCConversion]::New()
+                $Obj_Conversion.Resource_Name = $Obj_Export_Group.Name
                 $Composite_Resource = $Obj_M365DataExample.NonNodeData.$Workload.GetEnumerator() | Where-Object {
-                    $_.Name -match [regex]('^{0}[s]*$' -f ($Obj_Export_Group.Name `
-                                -replace "^$($Workload | Convert-M365WorkLoadName )" `
-                                -replace '(?<!y)$', '[s]*' `
-                                -replace 'y$', '(y|ies)' `
-                                -replace 'Policy', 'Policies' `
-                                -replace 'Profile', 'Profiles'
-                        ) ) }
-                $Obj_Conversion.Composite_Resource_Name = $Composite_Resource.Name
+                    $_.Name -eq ($Obj_Export_Group.Name -replace "^$($Workload | Convert-M365WorkLoadName )")
+                }
 
-                Foreach ($Group in $Obj_Export_Group.group)
+                if ($null -eq $Composite_Resource) { continue }
+
+                $Obj_Conversion.Composite_Resource_Name = $Composite_Resource.Name
+                $Obj_Conversion.IsCollection = $Composite_Resource.Value -is [System.Array]
+                $Obj_Conversion.RequiresUniqueId = $Composite_Resource.Value.ContainsKey('UniqueId')
+
+                foreach ($Group in $Obj_Export_Group.group)
                 {
                     $Obj_Conversion.Resource_Objects += ($Group | Copy-ObjectGraph -MapAs hashtable )
                 }
+
                 #Filter
                 if ($Obj_Conversion.Composite_Resource_Name)
                 {
@@ -130,14 +205,29 @@ function Convert-M365DSCExportToPowerShellDataFile
         )
 
         # Compose file
-        $Obj_Result = @{NonNodeData = @{$Workload = @{} } }
+        'Converting exported resources' | Write-Log
+        $Obj_Result = @{ NonNodeData = @{ $Workload = @{} } }
 
-        foreach ( $Collection in $Obj_Grouped )
+        foreach ($Collection in $Obj_Grouped)
         {
-            $Obj_Result.NonNodeData.$workload += @{$Collection.Composite_Resource_Name = @() }
-            foreach ($Resource in $Collection.Resource_Objects)
+            if ($Collection.IsCollection)
             {
-                $Obj_Result.NonNodeData.$workload.($Collection.Composite_Resource_Name) += $Resource
+                $Obj_Result.NonNodeData.$workload += @{$Collection.Composite_Resource_Name = @() }
+                foreach ($Resource in $Collection.Resource_Objects)
+                {
+                    $Obj_Result.NonNodeData.$workload.($Collection.Composite_Resource_Name) += $Resource
+                }
+                if ($Collection.RequiresUniqueId)
+                {
+                    foreach ($item in $Obj_Result.NonNodeData.$workload.($Collection.Composite_Resource_Name))
+                    {
+                        $item.UniqueId = $item.ResourceInstanceName
+                    }
+                }
+            }
+            else
+            {
+                $Obj_Result.NonNodeData.$workload.($Collection.Composite_Resource_Name) = $Collection.Resource_Objects[0]
             }
         }
 
@@ -145,35 +235,119 @@ function Convert-M365DSCExportToPowerShellDataFile
         $InputNode = $Obj_Result | Get-Node
         $LeafNodes = $InputNode | Get-ChildNode -Recurse -Leaf
 
-        # Exclude Keys
-        $LeafNodes.where{ $_.Name -in $DSC_ExcludeKeys }.foreach{ $_.ParentNode.value.remove($_.name) }
-        $DSC_ExcludeKeys.foreach{ 'Remove excluded key: {0}' -f $_ | Write-Log }
+        "Fixing data issues and removing excluded keys:" | Write-Log
+        "  - $($DSC_ExcludeKeys -join ', ')" | Write-Log
+        foreach ($leafNode in $LeafNodes)
+        {
+            if ($leafNode.Name -in $DSC_ExcludeKeys)
+            {
+                $leafNode.ParentNode.Value.Remove($leafNode.Name)
+                continue
+            }
 
-        # Fix type Int after export ( bug? commandlet New-M365DSCReportFromConfiguration )
-        $Int_Nodes = $LeafNodes.where{ (Get-RefNodeExampleData -Node $_ -ReferenceObject $Obj_M365DataExample).type -in ('SInt32', 'UInt32', 'UInt64') }
-        $Int_Nodes.ForEach{ $_.Value = [int]$_.Value }
+            $leafNodeType = (Get-RefNodeExampleData -Node $leafNode -ReferenceObject $Obj_M365DataExample).Type
+
+            if ($null -eq $leafNodeType)
+            {
+                $leafNode.ParentNode.Value.Remove($leafNode.Name)
+                continue
+            }
+
+            if ($leafNodeType -in ('SInt32', 'UInt32', 'UInt64'))
+            {
+                $leafNode.Value = [int]$leafNode.Value
+                continue
+            }
+        }
+
+        'Adding UniqueId property where required' | Write-Log
+        $nodes = ($InputNode | Get-ChildNode -Recurse).Where{ $_ -is [PSListNode] -and $_.Value[0] -is [Hashtable] }
+        foreach ($node in $nodes)
+        {
+            $counter = 1
+            foreach ($obj in $node.Value)
+            {
+            if ($obj.ContainsKey('UniqueId') -eq $false)
+                {
+                    $uniqueName = "{0}_{1}" -f $node.Name,$counter
+                    $obj.UniqueId = $uniqueName
+                    $counter++
+                }
+            }
+        }
 
         # Sort-object
+        'Sorting converted data' | Write-Log
         $Obj_Result = $Obj_Result | Sort-ObjectGraph -PrimaryKey 'NodeName', 'Identity', 'UniqueId', 'SettingDefinitionId' -MaxDepth 20
 
         # Check if data is available
         if ($Obj_Result.NonNodeData.$Workload)
         {
-            $Obj_Result | ConvertTo-Expression -Depth 20 -Expand 20 | Out-File $Path_CompositeConfig -Force -Confirm:$false -Encoding UTF8
-            'Result Composite config created: {0}' -f $Path_CompositeConfig | Write-Log
+            $expression = $Obj_Result | ConvertTo-Expression -Depth 20 -Expand 20
+
+            # Fix for non-escaped single quotes that cause issues
+            $fancySingleQuotes = '[\u2018\u2019]'
+            $expression = $expression.ToString() -replace $fancySingleQuotes,"''"
+
+            $expression | Out-File $ResultFile -Force -Confirm:$false -Encoding UTF8
+            'Result Composite config created: {0}' -f $ResultFile | Write-Log
         }
         else
         {
             'No valid data in result ' | Write-Log -Failure
+            return
+        }
+
+        if (-not $SkipPesterTests)
+        {
+            # Running tests on converted data
+            'Running Type/Value tests on converted data ' | Write-Log
+            $exportedData = Import-PSDataFile -Path $ResultFile.ToString()
+
+            $includeRequired = @('UniqueId')
+            $excludeAvailableAsResource = @('*UniqueId','*IsSingleInstance','NonNodeData.Environment.Tokens*')
+
+            $params = @{
+                Test                       = 'TypeValue'
+                InputObject                = $exportedData
+                IncludeRequired            = $includeRequired
+                ExcludeAvailableAsResource = $excludeAvailableAsResource
+                PesterOutputObject         = $true
+            }
+            if ($ShowPesterScripts)
+            {
+                $params.PesterShowScript = $true
+            }
+            $typeValueTestResults = Test-M365DSCPowershellDataFile @params
+
+            'Running Required values tests on converted data ' | Write-Log
+            $params = @{
+                Test                       = 'Required'
+                InputObject                = $exportedData
+                ExcludeAvailableAsResource = $excludeAvailableAsResource
+                PesterOutputObject         = $true
+            }
+            if ($ShowPesterScripts)
+            {
+                $params.PesterShowScript = $true
+            }
+            $requiredTestResults = Test-M365DSCPowershellDataFile @params
         }
     }
 
     end
     {
-        # Cleaning
-        if (Test-Path -Path $Path_JsonReport)
+        if (-not $SkipPesterTests)
         {
-            Remove-Item $Path_JsonReport -Confirm:$false -Force
+            if ($typeValueTestResults.Result -ne 'Passed' -or $requiredTestResults.Result -ne 'Passed') {
+                'Errors in converted data ' | Write-Log -Failure
+            }
+            else
+            {
+                'All tests passed' | Write-Log
+            }
         }
+
+        'Completed conversion DSC export to data file' | Write-Log
     }
 }

--- a/source/Public/Test-M365DSCPowershellDataFile.ps1
+++ b/source/Public/Test-M365DSCPowershellDataFile.ps1
@@ -359,7 +359,14 @@ function Test-M365DSCPowershellDataFile
                     # Type Validation
                     if ($objRefNodeValue.type)
                     {
-                        "`$inputObject.{0} | {1}" -f $nodeObject.path , $(Pester_Type_Should_Command $objRefNodeValue.type)
+                        if ($objRefNodeValue.type -eq "DateTime")
+                        {
+                            "{{ [DateTime]`$inputObject.{0} }} | Should -Not -Throw -Because 'Should be a valid DateTime string'" -f $nodeObject.path
+                        }
+                        else
+                        {
+                            "`$inputObject.{0} | {1}" -f $nodeObject.path , $(Pester_Type_Should_Command $objRefNodeValue.type)
+                        }
                     }
 
                     # ValidationSet Validation
@@ -427,10 +434,10 @@ function Test-M365DSCPowershellDataFile
         'Create Hashtables for reference data ' | Write-Log
         [hashtable]$ht = @{}
         [hashtable]$htRequired = @{}
-        $nodeObject = $inputObject | Get-ChildNode
-        foreach ($node in $nodeObject)
+        $nodeObjects = $inputObject | Get-ChildNode
+        foreach ($nodeObject in $nodeObjects)
         {
-            foreach ($node in $($node | Get-ChildNode))
+            foreach ($node in $($nodeObject | Get-ChildNode))
             {
                 # Create Hashtabel Exampledata
                 $objM365DataExample | Get-node("$($node.path)") | Get-ChildNode -Recurse -IncludeSelf | ForEach-Object {

--- a/source/Public/Test-M365DSCPowershellDataFile.ps1
+++ b/source/Public/Test-M365DSCPowershellDataFile.ps1
@@ -424,8 +424,6 @@ function Test-M365DSCPowershellDataFile
         $pathM365DataExample = Join-Path -Path ($Module.path | Split-Path) -ChildPath 'M365ConfigurationDataExample.psd1'
         $objM365DataExample = Import-PSDataFile -path $pathM365DataExample.ToString()
 
-        ShowElapsed | Write-Log -Debug
-
         'Create Hashtables for reference data ' | Write-Log
         [hashtable]$ht = @{}
         [hashtable]$htRequired = @{}
@@ -475,8 +473,6 @@ function Test-M365DSCPowershellDataFile
             }
         }
 
-        ShowElapsed | Write-Log -Debug
-
         'Create pester rules' | Write-Log
 
         $pesterConfig = @(
@@ -517,8 +513,6 @@ function Test-M365DSCPowershellDataFile
             }
             '}'
         )
-
-        ShowElapsed | Write-Log -Debug
 
         # Remove empty lines from the $pesterConfig variable
         $pesterConfig = $pesterConfig | Where-Object { $_.Trim() -ne '' }
@@ -584,7 +578,5 @@ function Test-M365DSCPowershellDataFile
             }
             'Pester[{0}]  Tests:{1}  Passed:{2}  Failed:{3} ' -f $pesterResult.version, $pesterResult.TotalCount, $pesterResult.PassedCount, $pesterResult.FailedCount | Write-Log @splat
         }
-
-        ShowElapsed | Write-Log -Debug
     }
 }

--- a/tests/Unit/Public/Convert-M365DSCExportToPowerShellDataFile.tests.ps1
+++ b/tests/Unit/Public/Convert-M365DSCExportToPowerShellDataFile.tests.ps1
@@ -40,67 +40,208 @@ Describe Convert-M365DSCExportToPowerShellDataFile {
         }
 
         # Declare M365DSC functions, so they can be mocked
-        function Global:Set-M365DSCTelemetryOption {}
-        function Global:New-M365DSCReportFromConfiguration {}
+        function Global:Set-M365DSCTelemetryOption
+        {
+        }
+        function Global:New-M365DSCReportFromConfiguration
+        {
+        }
+        function Global:ConvertTo-DscObject
+        {
+        }
 
         Mock -CommandName Set-M365DSCTelemetryOption -MockWith {}
         Mock -CommandName New-M365DSCReportFromConfiguration -MockWith {}
         Mock -CommandName Write-Log -MockWith {}
 
-        Mock -CommandName Get-Item -MockWith {
+        # Mock -CommandName Get-Item -MockWith {
+        #     return @{
+        #         BaseName = 'O365'
+        #     }
+        # }
+        # Mock -CommandName New-Item -MockWith {}
+        Mock -CommandName Out-File -MockWith {
+            $sb = [scriptblock]::Create($InputObject)
+            $global:ReturnedValue = $sb.Invoke()
+        }
+        Mock -CommandName Test-Path -MockWith { return $true }
+        # Mock -CommandName Remove-Item -MockWith {}
+        Mock -CommandName Get-Content -MockWith {
+            return @'
+# Generated with Microsoft365DSC version 1.25.326.1
+# For additional information on how to use Microsoft365DSC, please visit https://aka.ms/M365DSC
+param (
+)
+
+Configuration MyConfig
+{
+    param (
+    )
+
+    $OrganizationName = $ConfigurationData.NonNodeData.OrganizationName
+
+    Import-DscResource -ModuleName 'Microsoft365DSC' -ModuleVersion '1.25.326.1'
+
+    Node localhost
+    {
+        O365OrgSettings "O365OrgSettings"
+        {
+            AdminCenterReportDisplayConcealedNames                = $True;
+            AllowPlannerCopilot                                   = $True;
+            ApplicationId                                         = $ConfigurationData.NonNodeData.ApplicationId;
+            AppsAndServicesIsAppAndServicesTrialEnabled           = $False;
+            AppsAndServicesIsOfficeStoreEnabled                   = $False;
+            CertificateThumbprint                                 = $ConfigurationData.NonNodeData.CertificateThumbprint;
+            CortanaEnabled                                        = $False;
+            DynamicsCustomerVoiceIsInOrgFormsPhishingScanEnabled  = $True;
+            DynamicsCustomerVoiceIsRecordIdentityByDefaultEnabled = $False;
+            DynamicsCustomerVoiceIsRestrictedSurveyAccessEnabled  = $False;
+            FormsIsBingImageSearchEnabled                         = $False;
+            FormsIsExternalSendFormEnabled                        = $False;
+            FormsIsExternalShareCollaborationEnabled              = $False;
+            FormsIsExternalShareResultEnabled                     = $False;
+            FormsIsExternalShareTemplateEnabled                   = $False;
+            FormsIsInOrgFormsPhishingScanEnabled                  = $True;
+            FormsIsRecordIdentityByDefaultEnabled                 = $False;
+            InstallationOptionsAppsForMac                         = @("isMicrosoft365AppsEnabled");
+            InstallationOptionsAppsForWindows                     = @("isVisioEnabled","isProjectEnabled","isMicrosoft365AppsEnabled");
+            InstallationOptionsUpdateChannel                      = "semiAnnual";
+            IsSingleInstance                                      = "Yes";
+            M365WebEnableUsersToOpenFilesFrom3PStorage            = $False;
+            PlannerAllowCalendarSharing                           = $False;
+            TenantId                                              = $OrganizationName;
+            ToDoIsExternalJoinEnabled                             = $True;
+            ToDoIsExternalShareEnabled                            = $False;
+            ToDoIsPushNotificationEnabled                         = $True;
+            VivaInsightsDigestEmail                               = $False;
+            VivaInsightsOutlookAddInAndInlineSuggestions          = $False;
+            VivaInsightsScheduleSendSuggestions                   = $False;
+            VivaInsightsWebExperience                             = $False;
+        }
+    }
+}
+
+MyConfig -ConfigurationData .\ConfigurationData.psd1
+'@
+        }
+        Mock -CommandName ConvertTo-DSCObject -MockWith {
+            return @(
+                @{
+                    AdminCenterReportDisplayConcealedNames                = $true
+                    AllowPlannerCopilot                                   = $true
+                    ApplicationId                                         = '$ConfigurationData.NonNodeData.ApplicationId'
+                    AppsAndServicesIsAppAndServicesTrialEnabled           = $false
+                    AppsAndServicesIsOfficeStoreEnabled                   = $false
+                    CertificateThumbprint                                 = '$ConfigurationData.NonNodeData.CertificateThumbprint'
+                    CortanaEnabled                                        = $false
+                    DynamicsCustomerVoiceIsInOrgFormsPhishingScanEnabled  = $true
+                    DynamicsCustomerVoiceIsRecordIdentityByDefaultEnabled = $false
+                    DynamicsCustomerVoiceIsRestrictedSurveyAccessEnabled  = $false
+                    FormsIsBingImageSearchEnabled                         = $false
+                    FormsIsExternalSendFormEnabled                        = $false
+                    FormsIsExternalShareCollaborationEnabled              = $false
+                    FormsIsExternalShareResultEnabled                     = $false
+                    FormsIsExternalShareTemplateEnabled                   = $false
+                    FormsIsInOrgFormsPhishingScanEnabled                  = $true
+                    FormsIsRecordIdentityByDefaultEnabled                 = $false
+                    InstallationOptionsAppsForMac                         = @('isMicrosoft365AppsEnabled')
+                    InstallationOptionsAppsForWindows                     = @('isVisioEnabled', 'isProjectEnabled', 'isMicrosoft365AppsEnabled')
+                    InstallationOptionsUpdateChannel                      = 'semiAnnual'
+                    IsSingleInstance                                      = 'Yes'
+                    M365WebEnableUsersToOpenFilesFrom3PStorage            = $false
+                    PlannerAllowCalendarSharing                           = $false
+                    ResourceInstanceName                                  = 'O365OrgSettings'
+                    ResourceName                                          = 'O365OrgSettings'
+                    TenantId                                              = '$OrganizationName '
+                    ToDoIsExternalJoinEnabled                             = $true
+                    ToDoIsExternalShareEnabled                            = $false
+                    ToDoIsPushNotificationEnabled                         = $true
+                    VivaInsightsDigestEmail                               = $false
+                    VivaInsightsOutlookAddInAndInlineSuggestions          = $false
+                    VivaInsightsScheduleSendSuggestions                   = $false
+                    VivaInsightsWebExperience                             = $false
+                }
+            )
+        }
+        Mock -CommandName Start-Job -MockWith {
+            return @(
+                @{
+                    AdminCenterReportDisplayConcealedNames                = $true
+                    AllowPlannerCopilot                                   = $true
+                    ApplicationId                                         = '$ConfigurationData.NonNodeData.ApplicationId'
+                    AppsAndServicesIsAppAndServicesTrialEnabled           = $false
+                    AppsAndServicesIsOfficeStoreEnabled                   = $false
+                    CertificateThumbprint                                 = '$ConfigurationData.NonNodeData.CertificateThumbprint'
+                    CortanaEnabled                                        = $false
+                    DynamicsCustomerVoiceIsInOrgFormsPhishingScanEnabled  = $true
+                    DynamicsCustomerVoiceIsRecordIdentityByDefaultEnabled = $false
+                    DynamicsCustomerVoiceIsRestrictedSurveyAccessEnabled  = $false
+                    FormsIsBingImageSearchEnabled                         = $false
+                    FormsIsExternalSendFormEnabled                        = $false
+                    FormsIsExternalShareCollaborationEnabled              = $false
+                    FormsIsExternalShareResultEnabled                     = $false
+                    FormsIsExternalShareTemplateEnabled                   = $false
+                    FormsIsInOrgFormsPhishingScanEnabled                  = $true
+                    FormsIsRecordIdentityByDefaultEnabled                 = $false
+                    InstallationOptionsAppsForMac                         = @('isMicrosoft365AppsEnabled')
+                    InstallationOptionsAppsForWindows                     = @('isVisioEnabled', 'isProjectEnabled', 'isMicrosoft365AppsEnabled')
+                    InstallationOptionsUpdateChannel                      = 'semiAnnual'
+                    IsSingleInstance                                      = 'Yes'
+                    M365WebEnableUsersToOpenFilesFrom3PStorage            = $false
+                    PlannerAllowCalendarSharing                           = $false
+                    ResourceInstanceName                                  = 'O365OrgSettings'
+                    ResourceName                                          = 'O365OrgSettings'
+                    TenantId                                              = '$OrganizationName '
+                    ToDoIsExternalJoinEnabled                             = $true
+                    ToDoIsExternalShareEnabled                            = $false
+                    ToDoIsPushNotificationEnabled                         = $true
+                    VivaInsightsDigestEmail                               = $false
+                    VivaInsightsOutlookAddInAndInlineSuggestions          = $false
+                    VivaInsightsScheduleSendSuggestions                   = $false
+                    VivaInsightsWebExperience                             = $false
+                }
+            )
+        }
+
+        Mock -CommandName Test-M365DSCPowershellDataFile -MockWith {
             return @{
-                BaseName = 'O365'
+                Result = 'Passed'
             }
         }
-        Mock -CommandName New-Item -MockWith {}
-        Mock -CommandName Out-File -MockWith {}
-        Mock -CommandName Test-Path -MockWith { return $true}
-        Mock -CommandName Remove-Item -MockWith {}
-        Mock -CommandName Get-Content -MockWith {
-            return '[{"ResourceName":"O365OrgSettings","ResourceInstanceName":"O365OrgSettings","ApplicationId":"$ConfigurationData.NonNodeData.ApplicationId","CertificateThumbprint":"$ConfigurationData.NonNodeData.CertificateThumbprint","CortanaEnabled":false,"IsSingleInstance":"Yes","M365WebEnableUsersToOpenFilesFrom3PStorage":false,"PlannerAllowCalendarSharing":false,"TenantId":"$OrganizationName","VivaInsightsDigestEmail":false,"VivaInsightsOutlookAddInAndInlineSuggestions":false,"VivaInsightsScheduleSendSuggestions":false,"VivaInsightsWebExperience":false}]'
-        }
-        Mock -CommandName Get-Module -MockWith { return @{ Path = 'C:\Temp\module.psd1'} }
+        Mock -CommandName Get-Module -MockWith { return @{ Path = 'C:\Temp\module.psd1' } }
         Mock -CommandName Import-PSDataFile -MockWith {
             return @{
                 NonNodeData = @{
                     'Office365' = @{
                         OrgSettings = @{
-                            PlannerAllowCalendarSharing = 'Boolean | Optional | Allow Planner users to publish their plans and assigned tasks to Outlook or other calendars through iCalendar feeds.'
-                            ToDoIsExternalJoinEnabled = 'Boolean | Optional | To Do - Allow external users to join.'
-                            ToDoIsExternalShareEnabled = 'Boolean | Optional | To Do - Allow sharing with external users.'
-                            VivaInsightsScheduleSendSuggestions = 'Boolean | Optional | Specifies whether or not to allow users to have access to use the Viva Insights schedule send suggestions feature.'
-                            VivaInsightsWebExperience = 'Boolean | Optional | Specifies whether or not to allow users to have access to use the Viva Insights web experience.'
-                            VivaInsightsDigestEmail = 'Boolean | Optional | Specifies whether or not to allow users to have access to use the Viva Insights digest email feature.'
-                            VivaInsightsOutlookAddInAndInlineSuggestions = 'Boolean | Optional | Specifies whether or not to allow users to have access to use the Viva Insights Outlook add-in and inline suggestions.'
-                            ToDoIsPushNotificationEnabled = 'Boolean | Optional | To Do - Allow your users to receive push notifications.'
-                            InstallationOptionsAppsForMac = 'StringArray | Optional | Defines the apps users can install on Mac devices. | isSkypeForBusinessEnabled / isMicrosoft365AppsEnabled'
-                            AdminCenterReportDisplayConcealedNames = 'Boolean | Optional | Controls whether or not the Admin Center reports will conceale user, group and site names.'
-                            InstallationOptionsUpdateChannel = 'String | Optional | Defines how often you want your users to get feature updates for Microsoft 365 apps installed on devices running Windows | current / monthlyEnterprise / semiAnnual'
-                            InstallationOptionsAppsForWindows = 'StringArray | Optional | Defines the apps users can install on Windows and mobile devices. | isVisioEnabled / isSkypeForBusinessEnabled / isProjectEnabled / isMicrosoft365AppsEnabled'
-                            MicrosoftVivaBriefingEmail = 'Boolean | Optional | Specifies whether or not to let people in your organization receive Briefing email from Microsoft Viva.'
-                            DynamicsCustomerVoiceIsInOrgFormsPhishingScanEnabled = 'Boolean | Optional | Automatically block any internal surveys that request confidential information. Admins will be notified in the Message Center when a survey is blocked.'
+                            PlannerAllowCalendarSharing                           = 'Boolean | Optional | Allow Planner users to publish their plans and assigned tasks to Outlook or other calendars through iCalendar feeds.'
+                            ToDoIsExternalJoinEnabled                             = 'Boolean | Optional | To Do - Allow external users to join.'
+                            ToDoIsExternalShareEnabled                            = 'Boolean | Optional | To Do - Allow sharing with external users.'
+                            VivaInsightsScheduleSendSuggestions                   = 'Boolean | Optional | Specifies whether or not to allow users to have access to use the Viva Insights schedule send suggestions feature.'
+                            VivaInsightsWebExperience                             = 'Boolean | Optional | Specifies whether or not to allow users to have access to use the Viva Insights web experience.'
+                            VivaInsightsDigestEmail                               = 'Boolean | Optional | Specifies whether or not to allow users to have access to use the Viva Insights digest email feature.'
+                            VivaInsightsOutlookAddInAndInlineSuggestions          = 'Boolean | Optional | Specifies whether or not to allow users to have access to use the Viva Insights Outlook add-in and inline suggestions.'
+                            ToDoIsPushNotificationEnabled                         = 'Boolean | Optional | To Do - Allow your users to receive push notifications.'
+                            InstallationOptionsAppsForMac                         = 'StringArray | Optional | Defines the apps users can install on Mac devices. | isSkypeForBusinessEnabled / isMicrosoft365AppsEnabled'
+                            AdminCenterReportDisplayConcealedNames                = 'Boolean | Optional | Controls whether or not the Admin Center reports will conceale user, group and site names.'
+                            InstallationOptionsUpdateChannel                      = 'String | Optional | Defines how often you want your users to get feature updates for Microsoft 365 apps installed on devices running Windows | current / monthlyEnterprise / semiAnnual'
+                            InstallationOptionsAppsForWindows                     = 'StringArray | Optional | Defines the apps users can install on Windows and mobile devices. | isVisioEnabled / isSkypeForBusinessEnabled / isProjectEnabled / isMicrosoft365AppsEnabled'
+                            MicrosoftVivaBriefingEmail                            = 'Boolean | Optional | Specifies whether or not to let people in your organization receive Briefing email from Microsoft Viva.'
+                            DynamicsCustomerVoiceIsInOrgFormsPhishingScanEnabled  = 'Boolean | Optional | Automatically block any internal surveys that request confidential information. Admins will be notified in the Message Center when a survey is blocked.'
                             DynamicsCustomerVoiceIsRecordIdentityByDefaultEnabled = 'Boolean | Optional | Capture the first and last names of respondents in your organization that complete a survey. You can still change this for individual surveys.'
-                            DynamicsCustomerVoiceIsRestrictedSurveyAccessEnabled = 'Boolean | Optional | Capture the first and last names of respondents in your organization that complete a survey. You can still change this for individual surveys.'
-                            CortanaEnabled = 'Boolean | Optional | Allow Cortana in windows 10 (version 1909 and earlier), and the Cortana app on iOS and Android, to access Microsoft-hosted data on behalf of people in your organization.'
-                            AppsAndServicesIsAppAndServicesTrialEnabled = 'Boolean | Optional | Allow people in your organization to start trial subscriptions for apps and services that support trials. Admins manage licenses for these trials in the same way as other licenses in your organization. Only admins can upgrade these trials to paid subscriptions, so they won�??t affect your billing.'
-                            AppsAndServicesIsOfficeStoreEnabled = 'Boolean | Optional | Allow people in your organization to access the Office Store using their work account. The Office Store provides access to apps that aren''t curated or managed by Microsoft.'
-                            FormsIsBingImageSearchEnabled = 'Boolean | Optional | Allow YouTube and Bing.'
-                            FormsIsInOrgFormsPhishingScanEnabled = 'Boolean | Optional | Phishing protection.'
-                            FormsIsRecordIdentityByDefaultEnabled = 'Boolean | Optional | Record names of people in your org.'
-                            M365WebEnableUsersToOpenFilesFrom3PStorage = 'Boolean | Optional | Let users open files stored in third-party storage services in Microsoft 365 on the Web.'
-                            FormsIsExternalShareTemplateEnabled = 'Boolean | Optional | External Sharing - Share the form as a template that can be duplicated.'
-                            FormsIsExternalSendFormEnabled = 'Boolean | Optional | External Sharing - Send a link to the form and collect responses.'
-                            FormsIsExternalShareCollaborationEnabled = 'Boolean | Optional | External Sharing - Share to collaborate on the form layout and structure.'
-                            FormsIsExternalShareResultEnabled = 'Boolean | Optional | External Sharing - Share form result summary.'
+                            DynamicsCustomerVoiceIsRestrictedSurveyAccessEnabled  = 'Boolean | Optional | Capture the first and last names of respondents in your organization that complete a survey. You can still change this for individual surveys.'
+                            CortanaEnabled                                        = 'Boolean | Optional | Allow Cortana in windows 10 (version 1909 and earlier), and the Cortana app on iOS and Android, to access Microsoft-hosted data on behalf of people in your organization.'
+                            AppsAndServicesIsAppAndServicesTrialEnabled           = 'Boolean | Optional | Allow people in your organization to start trial subscriptions for apps and services that support trials. Admins manage licenses for these trials in the same way as other licenses in your organization. Only admins can upgrade these trials to paid subscriptions, so they won�??t affect your billing.'
+                            AppsAndServicesIsOfficeStoreEnabled                   = 'Boolean | Optional | Allow people in your organization to access the Office Store using their work account. The Office Store provides access to apps that aren''t curated or managed by Microsoft.'
+                            FormsIsBingImageSearchEnabled                         = 'Boolean | Optional | Allow YouTube and Bing.'
+                            FormsIsInOrgFormsPhishingScanEnabled                  = 'Boolean | Optional | Phishing protection.'
+                            FormsIsRecordIdentityByDefaultEnabled                 = 'Boolean | Optional | Record names of people in your org.'
+                            M365WebEnableUsersToOpenFilesFrom3PStorage            = 'Boolean | Optional | Let users open files stored in third-party storage services in Microsoft 365 on the Web.'
+                            FormsIsExternalShareTemplateEnabled                   = 'Boolean | Optional | External Sharing - Share the form as a template that can be duplicated.'
+                            FormsIsExternalSendFormEnabled                        = 'Boolean | Optional | External Sharing - Send a link to the form and collect responses.'
+                            FormsIsExternalShareCollaborationEnabled              = 'Boolean | Optional | External Sharing - Share to collaborate on the form layout and structure.'
+                            FormsIsExternalShareResultEnabled                     = 'Boolean | Optional | External Sharing - Share form result summary.'
                         }
-                    }
-                    'Teams' = @{
-                        Resource2 = @(
-                            @{
-                                Item3 = 'Boolean | Required | Required Boolean'
-                                Item4 = 'Guid | Optional | Optional Guid'
-                            }
-                        )
                     }
                 }
             }
@@ -109,10 +250,11 @@ Describe Convert-M365DSCExportToPowerShellDataFile {
 
     Context 'Test function Convert-M365DSCExportToPowerShellDataFile' {
         It 'Should convert an export successfully' {
-            Convert-M365DSCExportToPowerShellDataFile -Workload 'Office365' -SourceFile 'C:\Temp\O365.ps1' -ResultFolder 'C:\Temp\Report'
-            Should -Invoke Remove-Item
+            Convert-M365DSCExportToPowerShellDataFile -Workload 'Office365' -SourceFile 'C:\Temp\O365.ps1' -ResultFile 'C:\Temp\O365.psd1'
             Should -Invoke Out-File
+            $global:ReturnedValue.NonNodeData.Office365 | Should -BeOfType 'System.Collections.Hashtable'
+            $global:ReturnedValue.NonNodeData.Office365.OrgSettings | Should -BeOfType 'System.Collections.Hashtable'
+            $global:ReturnedValue.NonNodeData.Office365.OrgSettings.Count | Should -Be 26
         }
     }
 }
-


### PR DESCRIPTION
This PR updates the Convert-M365DSCExportToPowerShellDataFile function with the following updates:
- Check the schema for which type is expected for a specific resource, an array or an hashtable, and uses the correct type.
- Generates UniqueId properties for the collections that require it.
- Runs a Pester test to test if the exported values are of the right type and if all required properties are present.
- Add possibility to use PowerShell v7+, where some code is proxying requests via PowerShell v5.1.